### PR TITLE
preserve metadata.rb

### DIFF
--- a/lib/stove/packager.rb
+++ b/lib/stove/packager.rb
@@ -13,7 +13,7 @@ module Stove
       'CHANGELOG.*',
       'CONTRIBUTING.md',
       'MAINTAINERS.md',
-      'metadata.json',
+      'metadata.{json,rb}',
       'attributes/*.rb',
       'definitions/*.rb',
       'files/**/*',

--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -28,6 +28,7 @@ module Stove
           basic/files/default/patch.txt
           basic/libraries/magic.rb
           basic/metadata.json
+          basic/metadata.rb
           basic/providers/thing.rb
           basic/recipes/default.rb
           basic/recipes/system.rb


### PR DESCRIPTION
Changed to match berkshelf >= 7.0's behavior

Will allow people to download off of supermarket and modify the sources and
"recompile" into a new cookbook.
