### PR TITLE
Require Ruby 2.3 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
-distro: xenial
+dist: xenial
 language: ruby
 cache: bundler
-sudo: false
 
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
 
 # Only test master
 branches:

--- a/stove.gemspec
+++ b/stove.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |spec|
   spec.executables   = 'stove'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.3'
 
   # Runtime dependencies
   spec.add_dependency 'chef-api', '~> 0.5'
   spec.add_dependency 'logify',   '~> 0.2'
 
   spec.add_development_dependency 'aruba',          '~> 0.6.0'
-  spec.add_development_dependency 'bundler',        '~> 1.6'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'community-zero', '~> 2.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec',          '~> 3.0'


### PR DESCRIPTION
Unpin bundler so we can use bundler 2.0
Remove support for the EOL Ruby 2.2

Signed-off-by: Tim Smith <tsmith@chef.io>